### PR TITLE
fix error in example command

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ etc/ directory and relaunch your containers.
 
 For convenience, a user management tool is available as:
 
-    $ ./samba-docker usermod [add|delete|password] <user> <password>
+    $ ./docker-samba usermod [add|delete|password] <user> <password>
 
 The password option is mandatory for 'add' and 'password'. If
 supplied, the password is ignored for the 'delete' feature.
@@ -61,8 +61,8 @@ supplied, the password is ignored for the 'delete' feature.
 Running
 =======
 
-    $ ./samba-docker build
-    $ ./samba-docker launch
+    $ ./docker-samba build
+    $ ./docker-samba launch
 
 The build process should only need to be performed once, unless
 code changes have been made or an upgrade is being performed.


### PR DESCRIPTION
The command is called "docker-samba" and not "samba-docker"
